### PR TITLE
Don't require datasets.yml to exist for the examples() command.

### DIFF
--- a/pyct/cmd.py
+++ b/pyct/cmd.py
@@ -25,9 +25,9 @@ def _find_examples(name):
     raise ValueError("Could not find examples for %s at any of %s"%(name,candidates))
 
 def examples(name,path,verbose=False,force=False):
-    """Copy examples and fetch data to the supplied path. See copy-examples and fetch-data for more flexibility."""
+    """Copy examples and fetch data (if any) to the supplied path. See copy-examples and fetch-data for more flexibility."""
     copy_examples(name, path, verbose, force)
-    fetch_data(name,path)
+    fetch_data(name,path,require_datasets=False)
 
 
 def copy_examples(name,path,verbose=False,force=False):
@@ -310,7 +310,7 @@ def _process_dataset(dataset, output_dir, here):
         print('this download script requires the requests module: conda install requests')
         sys.exit(1)
 
-def fetch_data(name,path,datasets="datasets.yml"):
+def fetch_data(name,path,datasets="datasets.yml",require_datasets=True):
     '''Fetch sample datasets as defined by path/datasets if it exists or else module's own examples/datasets otherwise.
 
     Datasets are placed in path/data
@@ -320,6 +320,10 @@ def fetch_data(name,path,datasets="datasets.yml"):
     if not os.path.exists(info_file):
         info_file = os.path.join(_find_examples(name),datasets)
 
+    if not os.path.exists(info_file) and require_datasets is False:
+        print("No datasets to download") # data is added later...
+        return
+        
     print("Fetching data defined in %s and placing in %s"%(info_file,os.path.join(path,"data"))) # data is added later...
 
     with open(info_file) as f:

--- a/pyct/cmd.py
+++ b/pyct/cmd.py
@@ -321,7 +321,7 @@ def fetch_data(name,path,datasets="datasets.yml",require_datasets=True):
         info_file = os.path.join(_find_examples(name),datasets)
 
     if not os.path.exists(info_file) and require_datasets is False:
-        print("No datasets to download") # data is added later...
+        print("No datasets to download")
         return
         
     print("Fetching data defined in %s and placing in %s"%(info_file,os.path.join(path,"data"))) # data is added later...


### PR DESCRIPTION
pyct supplies the commands `copy-examples`, `fetch-data`, and `examples`. `examples` is a shortcut to run both `copy-examples` and `fetch-data`. Currently, `fetch-data` requires a datasets file to exist in the module, or to be supplied. But to allow projects to consistently instruct users to run `examples` - whether or not a project has any datasets - this PR makes having a dataset file optional when running the `examples` command.

I think there are various solutions to the problem described above. This particular solution seems simple, but am open to other suggestions.