### PR TITLE
Add test dependencies to conda recipe.

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,6 +26,10 @@ test:
   imports:
     - pyct
     - pyct.cmd
+  requires:
+    {% for dep in sdata['extras_require']['tests'] %}
+    - "{{ dep }}"
+    {% endfor %}
 
 about:
   home: {{ sdata['url'] }}


### PR DESCRIPTION
This is present in other pyviz projects (or should be...).

The next release of pyctdev does away with templating the conda build recipe like this, so would also have fixed this problem. However, it's not ready yet...
