### PR TITLE
Improving pytest 

### DIFF
--- a/pyct/tests/test_cmd.py
+++ b/pyct/tests/test_cmd.py
@@ -2,7 +2,7 @@ from pyct.cmd import fetch_data, clean_data, copy_examples, examples
 import pytest
 
 # Same as in pyct/examples/datasets.yml
-DATASETS_CONTENT = """
+DATASETS_CONTENT = u"""
 data:
   - url: this_should_never_be_used
     title: 'Test Data'
@@ -11,14 +11,14 @@ data:
 """
 
 # Same as in pyct/examples/data/.data_stubs/test_data.csv
-TEST_FILE_CONTENT = """
+TEST_FILE_CONTENT = u"""
 name,score,rank
 Alice,100.5,1
 Bob,50.3,2
 Charlie,25,3
 """
 
-REAL_FILE_CONTENT = """
+REAL_FILE_CONTENT = u"""
 name,score,rank
 Alice,100.5,1
 Bob,50.3,2
@@ -28,7 +28,7 @@ Eve,25,3
 Frank,75,9
 """
 
-FAKE_EXAMPLE_CONTENT = """
+FAKE_EXAMPLE_CONTENT = u"""
 import numpy as np
 
 a = np.arange(10)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands = flake8
 deps = .[tests]
 
 [_cmd_examples]
-commands = pytest --verbose
+commands = pytest pyct --verbose
 deps = .[tests,cmd]
 
 [_build_examples]


### PR DESCRIPTION
I made the tests pass with python 2.7 and made the command `pytest pyct` like `datashader` does: 

https://github.com/pyviz/datashader/blob/17629bd82708499beb0b990d7f092fd68ea3d172/tox.ini#L20

I am hoping we don't need more of this kind of thing:

https://github.com/pyviz/datashader/blob/17629bd82708499beb0b990d7f092fd68ea3d172/tox.ini#L60-L72